### PR TITLE
Confirmation token not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Simple confirmable logic for Rails apps. No baked in routing or mailers, just the barebones logic and migration you need to implement confirmable logic for your users.
 
 ## Installation
-Add `gem lp_confirmable, git: 'https://github.com/launchpadlab/lp_confirmable.git',` to your Gemfile and run `bundle install`.
+Add `gem 'lp_confirmable', git: 'https://github.com/launchpadlab/lp_confirmable.git',` to your Gemfile and run `bundle install`.
 
 ## Usage
 For the purposes of these instructions, I will assume the model you are using is 'User' but it could be anything you want.

--- a/lib/lp_confirmable/model.rb
+++ b/lib/lp_confirmable/model.rb
@@ -64,7 +64,7 @@ module LpConfirmable
       end
 
       def check_token_active!(model)
-        raise Error, 'token not found' unless model
+        raise Error, 'confirmation token not found' unless model
         raise Error, 'confirmation token expired' unless token_active?(model)
       end
 

--- a/lib/lp_confirmable/model.rb
+++ b/lib/lp_confirmable/model.rb
@@ -64,6 +64,7 @@ module LpConfirmable
       end
 
       def check_token_active!(model)
+        raise Error, 'token not found' unless model
         raise Error, 'confirmation token expired' unless token_active?(model)
       end
 

--- a/test/test_lp_confirmable.rb
+++ b/test/test_lp_confirmable.rb
@@ -149,6 +149,12 @@ describe LpConfirmable::Model do
       end
     end
 
+    it 'when model not found' do
+      assert_raises LpConfirmable::Error do
+        LPC.check_token_active!(nil)
+      end
+    end
+
     it 'when token active' do
       LpConfirmable.config { |config| config.token_lifetime = 14 }
       @confirmable_model.confirmation_token = 'foo'


### PR DESCRIPTION
When confirmation token isn't found for a record, we need to raise the LpConfirmable::Error (was just generically erring out)