### PR TITLE
retain token even after confirmed

### DIFF
--- a/lib/lp_confirmable/model.rb
+++ b/lib/lp_confirmable/model.rb
@@ -13,7 +13,6 @@ module LpConfirmable
         check_token_active! model
 
         model.update_columns(
-          confirmation_token: nil,
           confirmed_at: Time.now,
         )
 

--- a/lib/lp_confirmable/model.rb
+++ b/lib/lp_confirmable/model.rb
@@ -64,6 +64,7 @@ module LpConfirmable
 
       def check_token_active!(model)
         raise Error, 'confirmation token not found' unless model
+        raise Error, 'account already confirmed' unless model.confirmed_at.nil?
         raise Error, 'confirmation token expired' unless token_active?(model)
       end
 

--- a/test/test_lp_confirmable.rb
+++ b/test/test_lp_confirmable.rb
@@ -283,7 +283,7 @@ describe LpConfirmable::Model do
 
         it 'sets the confirmation token to nil' do
           model = LPC.confirm_by_token!(@klass, @token)
-          assert_nil model.confirmation_token
+          assert_equal model.confirmation_token, @token
         end
 
         it 'sets the confirmed at time to now' do

--- a/test/test_lp_confirmable.rb
+++ b/test/test_lp_confirmable.rb
@@ -44,6 +44,10 @@ class MockConfirmable < MockActiveRecord
       confirmable.confirmation_sent_at = Time.now - 1 * days
     end
 
+    if kwargs[:confirmation_token] == 'confirmed'
+      confirmable.confirmed_at = Time.now - 1 * days
+    end    
+
     confirmable
   end
 end
@@ -269,6 +273,19 @@ describe LpConfirmable::Model do
           end
         end
       end
+      
+      describe 'when confirmed' do
+        before do
+          @klass = MockConfirmable
+          @token = 'confirmed'
+        end
+
+        it 'raises' do
+          assert_raises LpConfirmable::Error do
+            LPC.confirm_by_token!(@klass, @token)
+          end
+        end
+      end      
 
       describe 'when active' do
         before do


### PR DESCRIPTION
Let's raise an appropriate error message when a user has already confirmed their account. We need to retain the confirmation token after a user has confirmed their account to do this.